### PR TITLE
Concurrency fixes

### DIFF
--- a/scraper_test.go
+++ b/scraper_test.go
@@ -126,16 +126,16 @@ func TestMakeTumblrURL(t *testing.T) {
 	}{
 		{
 			&User{name: "InitialUser"},
-			1, "http://InitialUser.tumblr.com/api/read/json?num=50&start=0",
+			1, "https://InitialUser.tumblr.com/api/read/json?num=50&start=0",
 		}, {
 			&User{name: "OtherPageUser"},
-			2, "http://OtherPageUser.tumblr.com/api/read/json?num=50&start=50",
+			2, "https://OtherPageUser.tumblr.com/api/read/json?num=50&start=50",
 		}, {
 			&User{name: "TaggedInitialUser", tag: "test"},
-			1, "http://TaggedInitialUser.tumblr.com/api/read/json?num=50&start=0&tagged=test",
+			1, "https://TaggedInitialUser.tumblr.com/api/read/json?num=50&start=0&tagged=test",
 		}, {
 			&User{name: "TaggedOtherPageUser", tag: "test"},
-			2, "http://TaggedOtherPageUser.tumblr.com/api/read/json?num=50&start=50&tagged=test",
+			2, "https://TaggedOtherPageUser.tumblr.com/api/read/json?num=50&start=50&tagged=test",
 		},
 	}
 

--- a/stats.go
+++ b/stats.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 )
 
 var gStats = NewGlobalStats()
@@ -58,14 +59,22 @@ func (g *GlobalStats) PrintStatus() {
 	}
 	fmt.Println()
 
-	fmt.Println(g.filesDownloaded, "/", g.filesFound-g.alreadyExists, "files downloaded.")
-	if g.alreadyExists != 0 {
-		fmt.Println(g.alreadyExists, "previously downloaded.")
+	filesFound := atomic.LoadUint64(&g.filesFound)
+	alreadyExists := atomic.LoadUint64(&g.alreadyExists)
+	filesDownloaded := atomic.LoadUint64(&g.filesDownloaded)
+	hardlinked := atomic.LoadUint64(&g.hardlinked)
+	bytesDownloaded := atomic.LoadUint64(&g.bytesDownloaded)
+	bytesOverhead := atomic.LoadUint64(&g.bytesOverhead)
+	bytesSaved := atomic.LoadUint64(&g.bytesSaved)
+
+	fmt.Println(filesDownloaded, "/", filesFound-alreadyExists, "files downloaded.")
+	if alreadyExists != 0 {
+		fmt.Println(alreadyExists, "previously downloaded.")
 	}
-	if g.hardlinked != 0 {
-		fmt.Println(g.hardlinked, "new hardlinks.")
+	if hardlinked != 0 {
+		fmt.Println(hardlinked, "new hardlinks.")
 	}
-	fmt.Println(byteSize(g.bytesDownloaded), "of files downloaded during this session.")
-	fmt.Println(byteSize(g.bytesOverhead), "of data downloaded as JSON overhead.")
-	fmt.Println(byteSize(g.bytesSaved), "of bandwidth saved due to hardlinking.")
+	fmt.Println(byteSize(bytesDownloaded), "of files downloaded during this session.")
+	fmt.Println(byteSize(bytesOverhead), "of data downloaded as JSON overhead.")
+	fmt.Println(byteSize(bytesSaved), "of bandwidth saved due to hardlinking.")
 }

--- a/user.go
+++ b/user.go
@@ -228,7 +228,12 @@ func (u *User) ProcessFile(f File, timestamp int64) {
 
 			atomic.AddUint64(&u.filesProcessed, 1)
 			atomic.AddUint64(&gStats.hardlinked, 1)
-			atomic.AddUint64(&gStats.bytesSaved, uint64(FileTracker.m[oldfile].FileInfo().Size()))
+			var v uint64
+			FileTracker.Lock()
+			v = uint64(FileTracker.m[oldfile].FileInfo().Size())
+			FileTracker.Unlock()
+
+			atomic.AddUint64(&gStats.bytesSaved, v)
 		}(f.Filename, pathname)
 		return
 	}

--- a/user.go
+++ b/user.go
@@ -195,14 +195,17 @@ func (u *User) String() string {
 // Used mostly with GlobalStats to show per-user download/scrape status.
 func (u *User) GetStatus() string {
 	isLimited := ""
-	if u.filesFound-u.filesProcessed > MaxQueueSize {
+	filesFound := atomic.LoadUint64(&u.filesFound)
+	filesProcessed := atomic.LoadUint64(&u.filesProcessed)
+	if filesFound-filesProcessed > MaxQueueSize {
 		isLimited = " [ LIMITED ]"
 	}
 
 	return fmt.Sprint(u.name, " - ", u.status,
-		" ( ", u.filesProcessed, "/", u.filesFound, " )", isLimited)
+		" ( ", filesProcessed, "/", filesFound, " )", isLimited)
 }
 
+// ProcessFile processes a given file
 func (u *User) ProcessFile(f File, timestamp int64) {
 	pathname := path.Join(cfg.DownloadDirectory, u.name, f.Filename)
 

--- a/walker.go
+++ b/walker.go
@@ -83,13 +83,18 @@ func (t *tracker) Link(oldfilename, newpath string) {
 }
 
 func (t *tracker) WaitForDownload(name string) {
-	<-t.m[name].Exists
+	t.Lock()
+	ch := t.m[name].Exists
+	t.Unlock()
+	<-ch
 }
 
 // Signal informs the goroutines waiting for a file to finish downloading that
 // the file specified is now present on disk. This allows them to hardlink to
 // it.
 func (t *tracker) Signal(file string) {
+	t.Lock()
+	defer t.Unlock()
 	close(t.m[file].Exists)
 }
 


### PR DESCRIPTION
This PR provides a number of fixes to the program which I had to apply for the program to work in a newer version of Go (1.9).

* The concurrent access protections should be fairly noncontroversial.
* Rather than just writing documentation to make golint happy, a better solution is probably to make a large set of the data structures local to the `main` package. Exporting them when there are no external user is probably not what we want to do.
* I removed a set of skipped test cases. This might not be what we want to do, because they look like they are there as reminders of things to add in the future to the system.
