### PR TITLE
Add go get instructions for fetching dependencies in make.sh

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 NAME='tumblr-downloader'
 
+echo "Fetching needed packages.."
+go get ./...
+echo "Done! Generating binaries for all operating systems.."
 for arch in amd64 386
 do
 	for os in linux darwin windows


### PR DESCRIPTION
As suggested in this issue: https://github.com/Liru/tumblr-downloader/issues/69
This PR add `go get` instructions for fetching needed dependencies before building the different binaries.